### PR TITLE
Fix Spanish website: Remove blog, update button links and text

### DIFF
--- a/src/components/Services-es.tsx
+++ b/src/components/Services-es.tsx
@@ -14,7 +14,7 @@ const services = [
       "Automatización de reservas, horarios y citas"
     ],
     icon: <Cog className="h-14 w-14 text-gialoma-gold" />,
-    link: "/services/process-automation"
+    link: "#contactos"
   },
   {
     id: 2,
@@ -26,7 +26,7 @@ const services = [
       "Integración de formularios inteligentes"
     ],
     icon: <Monitor className="h-14 w-14 text-gialoma-gold" />,
-    link: "/services/web-development"
+    link: "#contactos"
   },
   {
     id: 3,
@@ -38,7 +38,7 @@ const services = [
       "Integración con WhatsApp, web y redes sociales"
     ],
     icon: <Bot className="h-14 w-14 text-gialoma-gold" />,
-    link: "/services/ai-assistants"
+    link: "#contactos"
   },
   {
     id: 4,
@@ -50,7 +50,7 @@ const services = [
       "Diseño de plan de transformación digital"
     ],
     icon: <Briefcase className="h-14 w-14 text-gialoma-gold" />,
-    link: "/services/tech-consulting"
+    link: "#contactos"
   },
   {
     id: 5,
@@ -62,7 +62,7 @@ const services = [
       "Reportes automatizados"
     ],
     icon: <FileSpreadsheet className="h-14 w-14 text-gialoma-gold" />,
-    link: "/services/business-reporting"
+    link: "#contactos"
   },
   {
     id: 6,
@@ -74,7 +74,7 @@ const services = [
       "Integración de analíticas web"
     ],
     icon: <Search className="h-14 w-14 text-gialoma-gold" />,
-    link: "/services/digital-visibility"
+    link: "#contactos"
   }
 ];
 
@@ -139,6 +139,17 @@ const ServicesEs = () => {
       
       // Resume auto scrolling after manual interaction
       setTimeout(() => setIsAutoScrolling(true), 2000);
+    }
+  };
+
+  const handleServiceClick = (link: string) => {
+    if (link.startsWith('#')) {
+      const element = document.querySelector(link);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else {
+      window.location.href = link;
     }
   };
 
@@ -213,7 +224,7 @@ const ServicesEs = () => {
                     <Button 
                       variant="outline" 
                       className="text-gialoma-gold border-gialoma-gold hover:bg-gialoma-gold hover:text-white transition-colors flex items-center w-full justify-center"
-                      onClick={() => window.location.href = service.link}
+                      onClick={() => handleServiceClick(service.link)}
                     >
                       Saber Más <ArrowRight className="ml-2" size={16} />
                     </Button>
@@ -240,7 +251,7 @@ const ServicesEs = () => {
             className="bg-gialoma-gold hover:bg-gialoma-darkgold text-white"
             onClick={() => window.location.href = "/contactos"}
           >
-            Solicita una Consulta Gratuita
+            Solicita una Consulta
           </Button>
         </div>
       </div>

--- a/src/components/Solutions-es.tsx
+++ b/src/components/Solutions-es.tsx
@@ -12,7 +12,7 @@ const solutions = [
       "Automatiza tareas repetitivas",
       "Implementación de IA para resultados precisos"
     ],
-    link: "/solutions/time-saving"
+    link: "#contactos"
   },
   {
     icon: <Users className="h-12 w-12 text-gialoma-gold" />,
@@ -22,7 +22,7 @@ const solutions = [
       "Respuestas instantáneas con chatbots de IA",
       "Formularios y reservas online"
     ],
-    link: "/solutions/customer-service"
+    link: "#contactos"
   },
   {
     icon: <ChartBar className="h-12 w-12 text-gialoma-gold" />,
@@ -32,7 +32,7 @@ const solutions = [
       "Visibilidad en tiempo real de ventas, gastos y métricas",
       "Paneles intuitivos"
     ],
-    link: "/solutions/business-control"
+    link: "#contactos"
   },
   {
     icon: <Globe className="h-12 w-12 text-gialoma-gold" />,
@@ -42,7 +42,7 @@ const solutions = [
       "Sitios web optimizados que aparecen en Google",
       "Presencia activa en redes sociales y directorios empresariales"
     ],
-    link: "/solutions/digital-visibility"
+    link: "#contactos"
   },
   {
     icon: <HeartPulse className="h-12 w-12 text-gialoma-gold" />,
@@ -52,7 +52,7 @@ const solutions = [
       "Todos los datos centralizados y accesibles",
       "Reportes sin esfuerzo e insights automatizados"
     ],
-    link: "/solutions/stress-reduction"
+    link: "#contactos"
   },
   {
     icon: <Lightbulb className="h-12 w-12 text-gialoma-gold" />,
@@ -62,7 +62,7 @@ const solutions = [
       "Si eres analógico, te guiaremos paso a paso",
       "Si eres digital, te ayudaremos a escalar"
     ],
-    link: "/solutions/tech-guidance"
+    link: "#contactos"
   }
 ];
 
@@ -127,6 +127,17 @@ const SolutionsEs = () => {
       
       // Resume auto scrolling after manual interaction
       setTimeout(() => setIsAutoScrolling(true), 2000);
+    }
+  };
+
+  const handleSolutionClick = (link: string) => {
+    if (link.startsWith('#')) {
+      const element = document.querySelector(link);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else {
+      window.location.href = link;
     }
   };
 
@@ -208,7 +219,7 @@ const SolutionsEs = () => {
                   <Button 
                     variant="outline" 
                     className="bg-white text-black hover:text-gialoma-gold border-white hover:border-white flex items-center w-full justify-center transition-colors"
-                    onClick={() => window.location.href = solution.link}
+                    onClick={() => handleSolutionClick(solution.link)}
                   >
                     Saber Más <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>

--- a/src/pages/Index-es.tsx
+++ b/src/pages/Index-es.tsx
@@ -5,7 +5,7 @@ import HeroEs from '../components/Hero-es';
 import AboutEs from '../components/About-es';
 import SolutionsEs from '../components/Solutions-es';
 import ServicesEs from '../components/Services-es';
-import BlogEs from '../components/Blog-es';
+// Blog temporarily removed - import BlogEs from '../components/Blog-es';
 import TeamEs from '../components/Team-es';
 import TestimonialsEs from '../components/Testimonials-es';
 import CTAEs from '../components/CTA-es';
@@ -39,7 +39,7 @@ const IndexEs = () => {
       <AboutEs />
       <SolutionsEs />
       <ServicesEs />
-      <BlogEs />
+      {/* Blog temporarily removed - <BlogEs /> */}
       <TeamEs />
       <TestimonialsEs />
       <CTAEs />


### PR DESCRIPTION
## Spanish Website Fixes

This PR fixes the Spanish version issues that weren't properly applied in the previous merge:

### Changes Made:

1. **Blog Section Removed** from Spanish homepage
   - Removed `<BlogEs />` component from `Index-es.tsx`
   - Blog import commented out but preserved for future implementation

2. **Services Section (Spanish)**
   - All "Saber Más" buttons now link to `#contactos` (contact section)
   - Removed "gratuita" from button text: "Solicita una Consulta Gratuita" → "Solicita una Consulta"
   - Added proper scroll-to-contact functionality

3. **Solutions Section (Spanish)**
   - All "Saber Más" buttons now link to `#contactos` (contact section)
   - Added proper scroll-to-contact functionality

### Technical Implementation:

- All service and solution card buttons use `handleServiceClick` and `handleSolutionClick` functions
- Smooth scrolling to contact section using `scrollIntoView({ behavior: 'smooth' })`
- Contact section identified by `#contactos` ID for Spanish version
- Preserved all existing styling and animations

### Files Modified:

- `src/pages/Index-es.tsx` - Removed blog component
- `src/components/Services-es.tsx` - Updated button links and removed "gratuita"
- `src/components/Solutions-es.tsx` - Updated button links to contact

These changes ensure the Spanish version has the same behavior as requested for the English version.