### PR TITLE
Add logo link to gialoma.com in both Spanish and English navbars

### DIFF
--- a/src/components/Navbar-es.tsx
+++ b/src/components/Navbar-es.tsx
@@ -25,13 +25,13 @@ const NavbarEs = () => {
     <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${isScrolled ? 'bg-white shadow-md py-2 md:py-3' : 'bg-transparent py-3 md:py-5'}`}>
       <div className="container mx-auto px-4 flex justify-between items-center">
         <div className="flex items-center">
-          <Link to="/" className="flex items-center">
+          <a href="https://gialoma.com" className="flex items-center">
             <img 
               alt="Logo de Gialoma Life Solutions" 
               src="/lovable-uploads/4fe10b17-aa26-49e1-a9a2-e516e09ef670.png" 
               className="h-14 md:h-20 w-auto mr-3 object-contain transition-all duration-300" 
             />
-          </Link>
+          </a>
         </div>
 
         {/* Desktop Menu */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,13 +25,13 @@ const Navbar = () => {
     <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${isScrolled ? 'bg-white shadow-md py-2 md:py-3' : 'bg-transparent py-3 md:py-5'}`}>
       <div className="container mx-auto px-4 flex justify-between items-center">
         <div className="flex items-center">
-          <Link to="/en" className="flex items-center">
+          <a href="https://gialoma.com" className="flex items-center">
             <img 
               alt="Gialoma Life Solutions Logo" 
               src="/lovable-uploads/d3975bb5-3e96-450e-a77f-7fd8af9e04de.png" 
               className="h-14 md:h-20 w-auto mr-3 object-contain transition-all duration-300" 
             />
-          </Link>
+          </a>
         </div>
 
         {/* Desktop Menu */}


### PR DESCRIPTION
## Add Logo Link to gialoma.com

This PR updates the navbar logo links in both Spanish and English versions to point to `https://gialoma.com`, ensuring a consistent user experience.

### Changes Made:

1. **Spanish Navbar (`Navbar-es.tsx`)**
   - Changed logo link from `Link to="/"` to `<a href="https://gialoma.com">`
   - Logo now reloads the page from the beginning when clicked

2. **English Navbar (`Navbar.tsx`)**
   - Changed logo link from `Link to="/en"` to `<a href="https://gialoma.com">`
   - Logo now reloads the page from the beginning when clicked

### Technical Details:

- Replaced React Router `Link` components with standard HTML `<a>` tags for external navigation
- Both navbars now have consistent behavior
- Logo clicks will navigate to the main domain and reload the page completely
- Preserves all existing styling and responsive behavior

### User Experience:

- Users can now click the logo from any page to return to the homepage
- Consistent behavior across both language versions
- Standard web convention: logo always takes you home